### PR TITLE
Major update, see description

### DIFF
--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -15,7 +15,7 @@ component {
   this.ORMSettings = {
     datasource = "basecfc",
     dbcreate = "dropcreate",
-    cfclocation = this.root & "/model/beans"
+    cfclocation = expandPath( "./model/beans" )
   };
 
   public void function onRequestStart( ) {

--- a/tests/model/beans/invalid.cfc
+++ b/tests/model/beans/invalid.cfc
@@ -1,0 +1,3 @@
+component extends="basecfc.base" persistent=true {
+  property invalid;
+}

--- a/tests/model/beans/logging/contact.cfc
+++ b/tests/model/beans/logging/contact.cfc
@@ -1,0 +1,5 @@
+component extends="root.model.beans.logging.logged" persistent=true joinColumn="id" {
+  property email;
+  property name="createdObjects" singularname="createdObject" fieldtype="one-to-many" cfc="root.model.beans.logging.logged" FKColumn="createcontactid";
+  property name="updatedObjects" singularname="updatedObject" fieldtype="one-to-many" cfc="root.model.beans.logging.logged" FKColumn="updatecontactid";
+}

--- a/tests/model/beans/logging/logable.cfc
+++ b/tests/model/beans/logging/logable.cfc
@@ -1,0 +1,4 @@
+component extends="root.model.beans.logging.logged" persistent=true joinColumn="id" {
+  property aFieldToTest;
+  property thisWontChange;
+}

--- a/tests/model/beans/logging/logaction.cfc
+++ b/tests/model/beans/logging/logaction.cfc
@@ -1,0 +1,4 @@
+component extends="root.model.beans.logging.option" persistent=true table="option" discriminatorValue="logaction" {
+  property name="cssclass" length=32;
+  property name="logentries" singularName="logentry" fieldType="one-to-many" cfc="root.model.beans.logging.logentry" fkColumn="logactionid";
+}

--- a/tests/model/beans/logging/logentry.cfc
+++ b/tests/model/beans/logging/logentry.cfc
@@ -1,0 +1,68 @@
+component extends="basecfc.base" persistent=true {
+  property name;
+  property type="boolean" name="deleted" default="false";
+  property type="numeric" name="sortorder" default=0 ormType="integer";
+
+  property name="relatedEntity" fieldType="many-to-one" cfc="root.model.beans.logging.logged" FKColumn="entityid";
+  property name="logaction" fieldType="many-to-one" cfc="root.model.beans.logging.logaction" FKColumn="logactionid";
+  property name="savedState" length=4000;
+  property name="by" fieldType="many-to-one" cfc="root.model.beans.logging.contact" FKColumn="contactid";
+  property name="dd" ORMType="timestamp";
+  property name="ip" length=15;
+
+  public any function enterIntoLog( string action = "init", struct newState = { }, component entityToLog ) {
+    if ( isNull( entityToLog ) && !isNull( variables.relatedEntity ) ) {
+      entityToLog = variables.relatedEntity;
+    }
+
+    if ( isNull( entityToLog ) ) {
+      return this;
+    }
+
+    writeLog( text = "Logging entry for #entityToLog.getId( )#", file = request.appName );
+
+    var formData = {
+      "dd" = now( ),
+      "ip" = cgi.remote_addr,
+      "relatedEntity" = entityToLog.getId( )
+    };
+
+    if ( isDefined( "request.context.auth.userID" ) ) {
+      var contact = entityLoadByPK( "contact", request.context.auth.userID );
+
+      if ( !isNull( contact ) ) {
+        formData[ "by" ] = contact;
+      }
+    }
+
+    if ( len( trim( action ) ) ) {
+      var logaction = entityLoad( "logaction", { name = action }, true );
+
+      if ( isNull( logaction ) ) {
+        var logaction = entityLoad( "logaction", { name = "init" }, true );
+      }
+
+      if ( !isNull( logaction ) ) {
+        formData[ "logaction" ] = logaction;
+      }
+    }
+
+    if ( structIsEmpty( newState ) ) {
+      newState = { "init" = true, "name" = entityToLog.getName( ) };
+    }
+
+    formData[ "savedState" ] = left( serializeJson( deORM( newState ) ), 4000 );
+
+    transaction {
+      var result = save( formData );
+    }
+
+    var e = result.getRelatedEntity( );
+
+    if ( !isNull( e ) ) {
+      writeLog( text = "Entry logged for #e.getId( )#", file = request.appName );
+    }
+
+    return result;
+  }
+}

--- a/tests/model/beans/logging/logged.cfc
+++ b/tests/model/beans/logging/logged.cfc
@@ -1,0 +1,15 @@
+component extends="basecfc.base" persistent=true {
+  property name;
+  property type="boolean" name="deleted" default="false";
+  property type="numeric" name="sortorder" default=0 ormType="integer";
+
+  property name="createContact" fieldType="many-to-one" FKColumn="createcontactid" cfc="root.model.beans.logging.contact";
+  property name="createDate" ORMType="timestamp";
+  property name="createIP"  length=15;
+
+  property name="updateContact" fieldType="many-to-one" FKColumn="updatecontactid" cfc="root.model.beans.logging.contact";
+  property name="updateDate" ORMType="timestamp";
+  property name="updateIP" length=15;
+
+  property name="logEntries" singularName="logEntry" fieldType="one-to-many" cfc="root.model.beans.logging.logentry" FKColumn="entityid";
+}

--- a/tests/model/beans/logging/option.cfc
+++ b/tests/model/beans/logging/option.cfc
@@ -1,0 +1,12 @@
+component extends="basecfc.base" persistent=true table="option" discriminatorColumn="type" {
+  property name="name" type="string" length=128 inlist=true;
+  property name="deleted" type="boolean" ORMType="boolean" default=false inapi=false;
+  property name="sortorder" type="numeric" ORMType="integer" default=0;
+
+  property persistent=false name="type" inlist=true;
+  property persistent=false name="sourcecolumn" inlist=true;
+
+  function getType() {
+    return variables.instance.meta.discriminatorValue;
+  }
+}

--- a/tests/model/beans/o2o/oneA.cfc
+++ b/tests/model/beans/o2o/oneA.cfc
@@ -1,0 +1,7 @@
+component extends="basecfc.base" persistent=true {
+  property name="name" type="string" length=128;
+  property name="deleted" type="boolean" ORMType="boolean" default=false inapi=false;
+  property name="sortorder" type="numeric" ORMType="integer" default=0;
+
+  property name="b" fieldtype="one-to-one" cfc="root.model.beans.o2o.oneB" mappedby="a";
+}

--- a/tests/model/beans/o2o/oneB.cfc
+++ b/tests/model/beans/o2o/oneB.cfc
@@ -1,0 +1,7 @@
+component extends="basecfc.base" persistent=true {
+  property name="name" type="string" length=128;
+  property name="deleted" type="boolean" ORMType="boolean" default=false inapi=false;
+  property name="sortorder" type="numeric" ORMType="integer" default=0;
+
+  property name="a" fieldtype="one-to-one" cfc="root.model.beans.o2o.oneA" fkcolumn="a_id";
+}


### PR DESCRIPTION
- Add one-to-one support
- Add one-to-one test
- Add logging test
- Add object instantiation test
- Move all `fieldtype` functions (`to-many`, `to-one`, etc.) from a
giant switch to their own separate functions: `toMany()`, `toOne()` and
`oneToOne()`
- Move other bits of the `save()` function to their own functions
(`getObjectsToOverride()`, `getAllEntities()`,
`isObjectActionInQueue()`, `validateBaseProperties()`,
`getDefaultFields()`, `populateLogFields()`)
- Fix `transaction` and `ormFlush()` calls in test suite
- Add `dontLog()` function to (temporarily) disable logging on `save()`
call